### PR TITLE
Refactor code to do two getCat query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1456,6 +1456,11 @@
       "resolved": "https://registry.npmjs.org/@types/jest-diff/-/jest-diff-20.0.1.tgz",
       "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA=="
     },
+    "@types/lodash": {
+      "version": "4.14.134",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.134.tgz",
+      "integrity": "sha512-2/O0khFUCFeDlbi7sZ7ZFRCcT812fAeOLm7Ev4KbwASkZ575TDrDcY7YyaoHdTOzKcNbfiwLYZqPmoC4wadrsw=="
+    },
     "@types/node": {
       "version": "12.0.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "private": true,
   "dependencies": {
     "@types/jest": "24.0.13",
+    "@types/lodash": "^4.14.134",
     "@types/node": "12.0.4",
     "@types/react": "16.8.19",
     "@types/react-dom": "16.8.4",
     "@types/styled-components": "^4.1.16",
     "aws-amplify": "^1.1.28",
+    "lodash": "^4.17.11",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.1",

--- a/src/Cats/Cat.tsx
+++ b/src/Cats/Cat.tsx
@@ -5,12 +5,14 @@ import styled from 'styled-components'
 type CatProps = {
         id: string,
         url: string,
-        rating: string
+        rating: number,
+        opponentRating: number,
+        showWinner: Function
 }
 
-const Cat = ({url, rating}: CatProps) => {
+const Cat = ({id, url, rating, showWinner}: CatProps) => {
     return (
-        <CatsImgStyle src={url} alt={`Nice cat with a rating of ${rating}`}/>
+        <CatsImgStyle onClick={() => showWinner(id)} src={url} alt={`Nice cat with a rating of ${rating}`}/>
     )
 }
 

--- a/src/Cats/Cat.tsx
+++ b/src/Cats/Cat.tsx
@@ -3,15 +3,12 @@ import React from "react";
 import styled from 'styled-components'
 
 type CatProps = {
-    cat: {
         id: string,
         url: string,
         rating: string
-    }
 }
 
-const Cats = (props: CatProps) => {
-    const { url, rating } = props.cat
+const Cat = ({url, rating}: CatProps) => {
     return (
         <CatsImgStyle src={url} alt={`Nice cat with a rating of ${rating}`}/>
     )
@@ -23,4 +20,4 @@ const CatsImgStyle = styled.img`
     margin: 20px;
 `
 
-export default Cats
+export default Cat

--- a/src/Cats/CatsContainer.tsx
+++ b/src/Cats/CatsContainer.tsx
@@ -17,31 +17,45 @@ const CatsContainer: React.FC = () => {
     const [cat1, setCat1] = useState();
     const [cat2, setCat2] = useState();
 
-    const handleClick = () => {
+    useEffect(() => {
+      fetch2RandomCats()
+    }, [])
+
+    const getStarted = () => {
       setStarted(true);
     }
 
-    useEffect(() => {
-        fetchCat1()
-        fetchCat2()
-    }, [])
-
-    async function fetchCat1() {
-      const data: any = await API.graphql(graphqlOperation(queries.getCat1: {id: "lola"})
-      setCat1(data.data.getCat);
+    const fetch2RandomCats = () => {
+      const randomCat1: string = `${random(1, 99)}`
+      fetchCat1(randomCat1)
+      const randomCat2: string = `${random(1, 99)}`
+      fetchCat2(randomCat2)
     }
 
-    async function fetchCat2() {
-      const data: any = await API.graphql(graphqlOperation(queries.getCat2))
-      setCat2(data.data.getCat);
+    async function fetchCat1(id : string) {
+
+      const data: any = await API.graphql(graphqlOperation(queries.getCat1(id)))
+      setCat1(data.data.getCat)
+    }
+
+    async function fetchCat2(id : string) {
+      const data: any = await API.graphql(graphqlOperation(queries.getCat2(id)))
+      setCat2(data.data.getCat)
+    }
+
+    const showWinner = (winnerId: string) => {
+      alert(winnerId)
     }
 
     const start = started === false
-      ? <button onClick={() => handleClick()}>Start</button>
-      : <CatsContainerStyle>
-          <Cat id={cat1.id} url={cat1.url} rating={cat1.rating} />
-          <Cat id={cat2.id} url={cat2.url} rating={cat2.rating} />
-        </CatsContainerStyle>
+      ? <button onClick={() => getStarted()}>Start</button>
+      : <>
+          <CatsContainerStyle>
+            <Cat id={cat1.id} url={cat1.url} rating={cat1.rating} opponentRating={cat2.rating} showWinner={showWinner} />
+            <Cat id={cat2.id} url={cat2.url} rating={cat2.rating} opponentRating={cat1.rating} showWinner={showWinner} />
+          </CatsContainerStyle>
+          <button onClick={() => fetch2RandomCats()}>Next</button>
+        </>
     
     return start
 }

--- a/src/Cats/CatsContainer.tsx
+++ b/src/Cats/CatsContainer.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { API, graphqlOperation } from "aws-amplify";
 import * as queries from '../graphql/queries';
+import { random } from 'lodash';
 import styled from 'styled-components'
 
-import Cats from './Cats';
+import Cat from './Cat';
 
 interface ICat {
   id: string;
@@ -13,29 +14,36 @@ interface ICat {
 
 const CatsContainer: React.FC = () => {
     const [started, setStarted] = useState(false);
-    const [cats, setCats] = useState([]);
-
-    async function fetchCats() {
-      const data: any = await API.graphql(graphqlOperation(queries.getRandom2Cats));
-      console.log(data.data.getRandomCats);
-      setCats(data.data.getRandomCats)
-    }
+    const [cat1, setCat1] = useState();
+    const [cat2, setCat2] = useState();
 
     const handleClick = () => {
       setStarted(true);
-      fetchCats();
+    }
+
+    useEffect(() => {
+        fetchCat1()
+        fetchCat2()
+    }, [])
+
+    async function fetchCat1() {
+      const data: any = await API.graphql(graphqlOperation(queries.getCat1: {id: "lola"})
+      setCat1(data.data.getCat);
+    }
+
+    async function fetchCat2() {
+      const data: any = await API.graphql(graphqlOperation(queries.getCat2))
+      setCat2(data.data.getCat);
     }
 
     const start = started === false
       ? <button onClick={() => handleClick()}>Start</button>
       : <CatsContainerStyle>
-          {cats.map((cat: ICat) => (
-                <Cats key={cat.id} cat={cat} />
-            ))}
+          <Cat id={cat1.id} url={cat1.url} rating={cat1.rating} />
+          <Cat id={cat2.id} url={cat2.url} rating={cat2.rating} />
         </CatsContainerStyle>
-    return (
-      start
-    )
+    
+    return start
 }
 
 const CatsContainerStyle = styled.section`

--- a/src/aws-exports.js
+++ b/src/aws-exports.js
@@ -5,7 +5,7 @@ const config = {
     "aws_appsync_graphqlEndpoint": "https://gaqlvks7pbfoxfj4jqs3ultga4.appsync-api.eu-west-1.amazonaws.com/graphql",
     "aws_appsync_region": "eu-west-1",
     "aws_appsync_authenticationType": "API_KEY",
-    "aws_appsync_apiKey": "da2-dl2ewdqxnfblvfex654igltgui"
+    "aws_appsync_apiKey": "da2-3jtvz7qiunf4xckosz2sxuhlpu"
 };
 
 export default config;

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -1,10 +1,23 @@
-export const getRandom2Cats = `
-    query Get2RandomCats {
-        # Getting 2 cats randomly from DB
-        getRandomCats(limit: 2){
-            ...catFields
-        }
+export const getCat1 = `
+  query {
+    getCat(id: $id){
+      ...catFields
     }
+  }
+
+  fragment catFields on Cat {
+    id
+    url
+    rating
+  }
+`;
+
+export const getCat2 = `
+  query {
+    getCat(id: $id){
+      ...catFields
+    }
+  }
 
   fragment catFields on Cat {
     id

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -1,6 +1,6 @@
-export const getCat1 = `
-  query {
-    getCat(id: $id){
+export const getCat1 = (id) => { return `
+  query GetCat1 {
+    getCat(id: "${id}"){
       ...catFields
     }
   }
@@ -10,11 +10,11 @@ export const getCat1 = `
     url
     rating
   }
-`;
+`};
 
-export const getCat2 = `
-  query {
-    getCat(id: $id){
+export const getCat2 = (id) => { return `
+  query GetCat2 {
+    getCat(id: "${id}"){
       ...catFields
     }
   }
@@ -24,4 +24,4 @@ export const getCat2 = `
     url
     rating
   }
-`;
+`};


### PR DESCRIPTION
Hello 👋 

I've been really struggling with how AppSync handles resolvers in GraphQL. They use a query language called Velocity Template Language (VTL) for their DynamoDB. I spent about 4 hours this weekend trying to create a resolver in that language without much success. It was really frustrating.

On Monday, I started looking into Lambda functions for my resolvers. One of the AppSync Developer Advocate that I met while attending React Europe Hackathon advised me to go that route. He also published an article yesterday to help people understand how to use Lambda with AWS AppSync - https://dev.to/dabit3/lambda-function-graphql-resolvers-11cd

Unfortunately, I wasn't able to create a resolver but I was able to actually get two random cats.

Today, I decided to scratch the best practices and get the job done. It's still good code but I might get back to trying to create a resolver with Lambda functions once I'm done with the test.

**Total = 13 hours**

